### PR TITLE
Update coversheet to use create_venv.py instead of INSTALL.sh (#19)

### DIFF
--- a/coversheet/cli.py
+++ b/coversheet/cli.py
@@ -67,7 +67,7 @@ def main():
                     help = "post results to Autolog")
   parser.add_option("--testfile",
                     action = "store", type = "string", dest = "testfile",
-                    default = '../../services/sync/tests/tps/test_sync.js',
+                    default = 'all_tests.json',
                     help = "path to the test file to run "
                            "[default: %default]")
   parser.add_option("--logfile",

--- a/coversheet/subproc.py
+++ b/coversheet/subproc.py
@@ -152,11 +152,13 @@ class TPSSubproc():
         if os.access(self.tpsenv, os.F_OK):
             shutil.rmtree(self.tpsenv)
         print "Installing tps in %s" % self.tpsenv
-        self.run_process(["sh",
-                          os.path.join(self.tpswd, "INSTALL.sh"),
-                          self.tpsenv],
-                          self.tpswd,
-                          ignoreFailures=True)
+        create_venv = os.path.join(self.tpswd, 'create_venv.py')
+        if os.path.exists(create_venv):
+            cmd_args = ["python", create_venv, self.tpsenv]
+        else:
+            cmd_args = ["sh", os.path.join(self.tpswd, "INSTALL.sh"),
+                        self.tpsenv]
+        self.run_process(cmd_args, self.tpswd, ignoreFailures=True)
         print "TPS setup complete"
 
     def update_config(self):


### PR DESCRIPTION
This is for issue #19
I tested this with a patched tests_zip file and it works both with INSTALL.sh and create_venv.py
